### PR TITLE
implement fmt::Debug for `no_std` as well

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,18 +113,7 @@ pub enum FromHexError {
     InvalidHexLength,
 }
 
-#[cfg(feature = "std")]
-impl fmt::Debug for FromHexError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            InvalidHexCharacter(ch, idx) =>
-                write!(f, "Invalid character '{}' at position {}", ch, idx),
-            InvalidHexLength => write!(f, "Invalid input length"),
-        }
-    }
-}
-
-#[cfg(not(feature = "std"))]
+#[cfg(any(feature = "std", test))]
 impl fmt::Debug for FromHexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,6 @@ pub enum FromHexError {
     InvalidHexLength,
 }
 
-#[cfg(any(feature = "std", test))]
 impl fmt::Debug for FromHexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,17 @@ impl fmt::Debug for FromHexError {
     }
 }
 
+#[cfg(not(feature = "std"))]
+impl fmt::Debug for FromHexError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            InvalidHexCharacter(ch, idx) =>
+                write!(f, "Invalid character '{}' at position {}", ch, idx),
+            InvalidHexLength => write!(f, "Invalid input length"),
+        }
+    }
+}
+
 #[cfg(feature = "std")]
 impl ::std::error::Error for FromHexError {
     fn description(&self) -> &str {


### PR DESCRIPTION
Lets tests run without default features in consuming crates.