### PR TITLE
Expose iterators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-hex"
-version = "2.0.1"
+version = "2.1.0"
 authors = ["The Rust Project Developers", "debris <marek.kotewicz@gmail.com>", "Robert Habermeier"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/debris/rustc-hex"
@@ -9,6 +9,7 @@ keywords = ["rustc", "serialize", "hex"]
 description = """
 rustc-serialize compatible hex conversion traits
 """
+edition = "2018"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Currently the traits require you to collect and allocate the resulting string or vector of bytes. This PR exposes underlying iterators as well, so that it's possible to process bytes/characters one at a time without a need to allocate everything.

Also updates the code to `edition=2018`.

One possible improvement would be to have `FromHexIter` work with any `Iterator<Item = &char>` instead of only existing `str` slice.